### PR TITLE
Handle template load failures with defaults

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import json
 import re
 import sqlite3
 import time
+from copy import deepcopy
 from datetime import datetime
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
@@ -125,15 +126,27 @@ def _build_title_tags_defaults(film_type_names, base_title, base_tags):
 
 def load_templates():
     if not os.path.exists(TEMPLATES_FILE):
-        with open(TEMPLATES_FILE, "w", encoding="utf-8") as f:
-            json.dump(DEFAULT_TEMPLATES, f, ensure_ascii=False, indent=2)
-        return DEFAULT_TEMPLATES.copy()
-    with open(TEMPLATES_FILE, "r", encoding="utf-8") as f:
-        data = json.load(f)
+        defaults = deepcopy(DEFAULT_TEMPLATES)
+        save_templates(defaults)
+        return defaults
+
+    try:
+        with open(TEMPLATES_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        defaults = deepcopy(DEFAULT_TEMPLATES)
+        save_templates(defaults)
+        return defaults
+
+    if not isinstance(data, dict):
+        defaults = deepcopy(DEFAULT_TEMPLATES)
+        save_templates(defaults)
+        return defaults
+
     # гарантуємо всі ключі
     for k, v in DEFAULT_TEMPLATES.items():
         if k not in data:
-            data[k] = v
+            data[k] = deepcopy(v)
     return data
 
 def save_templates(dct):


### PR DESCRIPTION
## Summary
- wrap `load_templates` file IO in a defensive try/except and accept only dict payloads
- fall back to deep copies of `DEFAULT_TEMPLATES` and immediately rewrite `templates.json` when recovery is needed
- ensure new files and missing keys use deep copies to avoid mutating the in-memory defaults

## Testing
- python - <<'PY'
import sys, types
ctk = types.ModuleType('customtkinter')
class Dummy:
    def __init__(self, *a, **kw):
        pass
    def pack(self, *a, **kw):
        pass
    def grid(self, *a, **kw):
        pass
    def place(self, *a, **kw):
        pass
    def configure(self, *a, **kw):
        pass
    def destroy(self):
        pass
    def bind(self, *a, **kw):
        pass
    def pack_forget(self, *a, **kw):
        pass
    def grid_columnconfigure(self, *a, **kw):
        pass
    def grid_rowconfigure(self, *a, **kw):
        pass
ctk.CTk = ctk.CTkToplevel = ctk.CTkFrame = ctk.CTkEntry = ctk.CTkButton = Dummy
ctk.CTkLabel = ctk.CTkOptionMenu = ctk.CTkTextbox = ctk.CTkTabview = Dummy
ctk.CTkCheckBox = ctk.CTkComboBox = Dummy
ctk.CTkFont = lambda *a, **kw: None
ctk.StringVar = lambda *a, **kw: None
ctk.BooleanVar = lambda *a, **kw: None
ctk.set_appearance_mode = lambda *a, **kw: None
ctk.set_default_color_theme = lambda *a, **kw: None
ctk.get_appearance_mode = lambda: 'light'
sys.modules['customtkinter'] = ctk
pd = types.ModuleType('pandas')
class _DF:
    def to_excel(self, *a, **kw):
        pass
    def to_csv(self, *a, **kw):
        pass
class _DataFrame:
    @staticmethod
    def from_records(*a, **kw):
        return _DF()
pd.DataFrame = _DataFrame
sys.modules['pandas'] = pd
jinja2 = types.ModuleType('jinja2')
class _Template:
    def __init__(self, *a, **kw):
        pass
    def render(self, *a, **kw):
        return ''
class _TemplateError(Exception):
    pass
jinja2.Template = _Template
jinja2.TemplateError = _TemplateError
sys.modules['jinja2'] = jinja2
import main
from pathlib import Path
# create a corrupt templates.json
Path('templates.json').write_text('{"oops": true', encoding='utf-8')
# ensure load_templates restores defaults and rewrites the file
restored = main.load_templates()
assert restored['title_template'] == main.DEFAULT_TEMPLATES['title_template']
assert '"film_types"' in Path('templates.json').read_text(encoding='utf-8')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d1bcd8e228832586652144c0ccbb4e