### PR TITLE
Add export formula validation and hints

### DIFF
--- a/formula_engine.py
+++ b/formula_engine.py
@@ -1,0 +1,896 @@
+"""Formula evaluation engine with Google Sheets-like syntax.
+
+This module exposes :class:`FormulaEngine`, which can parse and evaluate
+expressions that mimic a subset of Google Sheets formulas.  The engine is
+designed to be safe (no ``eval`` usage), extensible (custom functions can be
+registered), and convenient for templating data exports where variables are
+embedded in ``{{variable}}`` placeholders.
+
+The supported feature-set includes arithmetic, comparisons, string
+concatenation, and a collection of spreadsheet-inspired functions such as
+``IF``, ``SUM``, ``TEXT`` and ``TODAY``.  Arguments inside formulas are
+separated with semicolons to match the locale-specific style used in the
+examples (e.g. ``=SUM(1; 2; 3)``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from decimal import Decimal, ROUND_HALF_UP
+import inspect
+import math
+import re
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
+
+
+class FormulaError(Exception):
+    """Raised when a formula cannot be parsed or evaluated."""
+
+
+@dataclass(frozen=True)
+class _Token:
+    """Single lexical token produced by the tokenizer."""
+
+    type: str
+    value: Any
+
+
+class _Tokenizer:
+    """Turn a formula string into a stream of tokens."""
+
+    _NUMBER_RE = re.compile(r"[+-]?((\d+\.\d*)|(\d*\.\d+)|(\d+))(e[+-]?\d+)?", re.IGNORECASE)
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.length = len(text)
+        self.pos = 0
+
+    def tokenize(self) -> List[_Token]:
+        tokens: List[_Token] = []
+        while self.pos < self.length:
+            ch = self.text[self.pos]
+            if ch.isspace():
+                self.pos += 1
+                continue
+            if ch == '{' and self._peek('{'):
+                tokens.append(self._consume_variable())
+                continue
+            if ch == '"':
+                tokens.append(self._consume_string())
+                continue
+            if ch.isdigit() or (ch in '+-' and self._peek_digit()):
+                tokens.append(self._consume_number())
+                continue
+            if ch.isalpha() or ch == '_':
+                tokens.append(self._consume_identifier())
+                continue
+            if ch == '(':
+                tokens.append(_Token('LPAREN', ch))
+                self.pos += 1
+                continue
+            if ch == ')':
+                tokens.append(_Token('RPAREN', ch))
+                self.pos += 1
+                continue
+            if ch in ';,':
+                tokens.append(_Token('SEMI', ch))
+                self.pos += 1
+                continue
+            if ch == '&':
+                tokens.append(_Token('OP', ch))
+                self.pos += 1
+                continue
+            # multi-character comparisons first
+            if self.text.startswith('>=', self.pos):
+                tokens.append(_Token('COMPARE', '>='))
+                self.pos += 2
+                continue
+            if self.text.startswith('<=', self.pos):
+                tokens.append(_Token('COMPARE', '<='))
+                self.pos += 2
+                continue
+            if self.text.startswith('<>', self.pos):
+                tokens.append(_Token('COMPARE', '<>'))
+                self.pos += 2
+                continue
+            if ch in '=<>':
+                tokens.append(_Token('COMPARE', ch))
+                self.pos += 1
+                continue
+            if ch in '+-*/^':
+                tokens.append(_Token('OP', ch))
+                self.pos += 1
+                continue
+            raise FormulaError(f"Unexpected character '{ch}' at position {self.pos}.")
+        tokens.append(_Token('EOF', None))
+        return tokens
+
+    def _peek(self, char: str) -> bool:
+        return self.pos + 1 < self.length and self.text[self.pos + 1] == char
+
+    def _peek_digit(self) -> bool:
+        return self.pos + 1 < self.length and self.text[self.pos + 1].isdigit()
+
+    def _consume_variable(self) -> _Token:
+        end = self.text.find('}}', self.pos)
+        if end == -1:
+            raise FormulaError("Unterminated variable placeholder.")
+        name = self.text[self.pos + 2 : end].strip()
+        if not name:
+            raise FormulaError("Empty variable placeholder encountered.")
+        self.pos = end + 2
+        return _Token('VAR', name)
+
+    def _consume_string(self) -> _Token:
+        self.pos += 1  # skip opening quote
+        buffer: List[str] = []
+        while self.pos < self.length:
+            ch = self.text[self.pos]
+            if ch == '"':
+                if self._peek('"'):
+                    buffer.append('"')
+                    self.pos += 2
+                    continue
+                self.pos += 1
+                return _Token('STRING', ''.join(buffer))
+            if ch == '\\':
+                self.pos += 1
+                if self.pos >= self.length:
+                    raise FormulaError("Invalid escape sequence in string literal.")
+                escape = self.text[self.pos]
+                escapes = {'n': '\n', 't': '\t', 'r': '\r', '"': '"', '\\': '\\'}
+                buffer.append(escapes.get(escape, escape))
+                self.pos += 1
+                continue
+            buffer.append(ch)
+            self.pos += 1
+        raise FormulaError("Unterminated string literal.")
+
+    def _consume_number(self) -> _Token:
+        match = self._NUMBER_RE.match(self.text, self.pos)
+        if not match:
+            raise FormulaError(f"Invalid number at position {self.pos}.")
+        literal = match.group(0)
+        self.pos = match.end()
+        if any(c in literal for c in '.eE'):
+            value: Any = float(literal)
+        else:
+            value = int(literal)
+        return _Token('NUMBER', value)
+
+    def _consume_identifier(self) -> _Token:
+        start = self.pos
+        self.pos += 1
+        while self.pos < self.length and (self.text[self.pos].isalnum() or self.text[self.pos] in '._'):
+            self.pos += 1
+        ident = self.text[start:self.pos]
+        upper = ident.upper()
+        if upper == 'TRUE':
+            return _Token('BOOLEAN', True)
+        if upper == 'FALSE':
+            return _Token('BOOLEAN', False)
+        if upper in {'NULL', 'NONE'}:
+            return _Token('NULL', None)
+        return _Token('IDENT', ident)
+
+
+class _Parser:
+    """Produce an abstract syntax tree from the token stream."""
+
+    _OP_PRECEDENCE: Dict[str, int] = {
+        '^': 4,
+        '*': 3,
+        '/': 3,
+        '+': 2,
+        '-': 2,
+        '&': 2,
+    }
+
+    def __init__(self, tokens: Sequence[_Token]) -> None:
+        self.tokens = tokens
+        self.pos = 0
+
+    def parse(self) -> Any:
+        expression = self._parse_expression()
+        self._expect('EOF')
+        return expression
+
+    def _parse_expression(self, min_precedence: int = 0, stop_types: Optional[Sequence[str]] = None) -> Any:
+        stop = set(stop_types or ())
+        node = self._parse_prefix(stop)
+        while True:
+            token = self._peek()
+            if token.type in stop or token.type == 'EOF':
+                break
+            if token.type == 'OP':
+                precedence = self._OP_PRECEDENCE[token.value]
+                if precedence < min_precedence:
+                    break
+                self._advance()
+                next_min = precedence + (0 if token.value == '^' else 1)
+                rhs = self._parse_expression(next_min, stop)
+                node = ('binop', token.value, node, rhs)
+                continue
+            if token.type == 'COMPARE':
+                precedence = 1
+                if precedence < min_precedence:
+                    break
+                op = token.value
+                self._advance()
+                rhs = self._parse_expression(precedence + 1, stop)
+                node = ('compare', op, node, rhs)
+                continue
+            break
+        return node
+
+    def _parse_prefix(self, stop: set[str]) -> Any:
+        token = self._advance()
+        if token.type == 'NUMBER':
+            return ('literal', token.value)
+        if token.type == 'STRING':
+            return ('literal', token.value)
+        if token.type == 'BOOLEAN':
+            return ('literal', token.value)
+        if token.type == 'NULL':
+            return ('literal', None)
+        if token.type == 'VAR':
+            return ('var', token.value)
+        if token.type == 'OP' and token.value in ('+', '-'):
+            operand = self._parse_expression(self._OP_PRECEDENCE['^'], stop)
+            return ('unary', token.value, operand)
+        if token.type == 'LPAREN':
+            expr = self._parse_expression(0, stop_types=('RPAREN',))
+            self._expect('RPAREN')
+            return expr
+        if token.type == 'IDENT':
+            next_token = self._peek()
+            if next_token.type == 'LPAREN':
+                self._advance()  # consume LPAREN
+                args = self._parse_arguments()
+                return ('func', token.value.upper(), args)
+            raise FormulaError(f"Unexpected identifier '{token.value}'. Variables must use {{}} notation.")
+        raise FormulaError(f"Unexpected token {token.type!r} in expression.")
+
+    def _parse_arguments(self) -> List[Any]:
+        args: List[Any] = []
+        if self._peek().type == 'RPAREN':
+            self._advance()
+            return args
+        while True:
+            args.append(self._parse_expression(0, stop_types=('SEMI', 'RPAREN')))
+            token = self._peek()
+            if token.type == 'SEMI':
+                self._advance()
+                continue
+            if token.type == 'RPAREN':
+                self._advance()
+                break
+            raise FormulaError("Expected ';' or ')' in function arguments.")
+        return args
+
+    def _peek(self) -> _Token:
+        return self.tokens[self.pos]
+
+    def _advance(self) -> _Token:
+        token = self.tokens[self.pos]
+        self.pos += 1
+        return token
+
+    def _expect(self, token_type: str) -> _Token:
+        token = self._advance()
+        if token.type != token_type:
+            raise FormulaError(f"Expected token {token_type!r}, found {token.type!r}.")
+        return token
+
+
+class FormulaEngine:
+    """Evaluates spreadsheet-like formulas in a controlled environment."""
+
+    FUNCTIONS: Dict[str, Callable[..., Any]] = {}
+
+    @classmethod
+    def register_function(cls, name: str, func: Callable[..., Any]) -> None:
+        """Register a callable under the provided uppercase name."""
+
+        if not callable(func):
+            raise TypeError("Registered function must be callable.")
+        cls.FUNCTIONS[name.upper()] = func
+
+    @classmethod
+    def _prepare_formula(cls, formula: str) -> Tuple[Optional[str], bool]:
+        expression = formula.strip()
+        if not expression:
+            return None, True
+        if expression.startswith('='):
+            expression = expression[1:]
+            if not expression.strip():
+                return None, True
+            expression = expression.strip()
+        return expression, False
+
+    @classmethod
+    def _parse_tokens(cls, expression: str) -> Any:
+        tokenizer = _Tokenizer(expression)
+        tokens = tokenizer.tokenize()
+        parser = _Parser(tokens)
+        return parser.parse()
+
+    @classmethod
+    def parse(cls, formula: str) -> Any:
+        if formula is None:
+            raise FormulaError("Formula is empty.")
+        if not isinstance(formula, str):
+            raise FormulaError("Formula must be a string.")
+        expression, is_blank = cls._prepare_formula(formula)
+        if expression is None or is_blank:
+            raise FormulaError("Formula is empty.")
+        return cls._parse_tokens(expression)
+
+    @classmethod
+    def describe(cls, formula: str) -> Dict[str, Any]:
+        ast = cls.parse(formula)
+        variables: set[str] = set()
+        functions: set[str] = set()
+        cls._collect_metadata(ast, variables, functions)
+        return {"ast": ast, "variables": variables, "functions": functions}
+
+    @classmethod
+    def _collect_metadata(cls, node: Any, variables: set[str], functions: set[str]) -> None:
+        node_type = node[0]
+        if node_type == 'var':
+            variables.add(node[1])
+            return
+        if node_type == 'func':
+            functions.add(node[1])
+            for arg in node[2]:
+                cls._collect_metadata(arg, variables, functions)
+            return
+        if node_type == 'unary':
+            cls._collect_metadata(node[2], variables, functions)
+            return
+        if node_type in ('binop', 'compare'):
+            cls._collect_metadata(node[2], variables, functions)
+            cls._collect_metadata(node[3], variables, functions)
+            return
+
+    @classmethod
+    def evaluate(cls, formula: str, context: Optional[Mapping[str, Any]] = None) -> Any:
+        """Evaluate a single formula using the supplied context."""
+
+        if formula is None:
+            return None
+        if not isinstance(formula, str):
+            return formula
+        expression, is_blank = cls._prepare_formula(formula)
+        if expression is None or is_blank:
+            return ''
+        ast = cls._parse_tokens(expression)
+        eval_context = dict(context or {})
+        return cls._evaluate_node(ast, eval_context)
+
+    @classmethod
+    def _evaluate_node(cls, node: Any, context: Mapping[str, Any]) -> Any:
+        node_type = node[0]
+        if node_type == 'literal':
+            return node[1]
+        if node_type == 'var':
+            name = node[1]
+            if name not in context:
+                raise FormulaError(f"Unknown variable '{name}'.")
+            value = context[name]
+            if callable(value):
+                value = value()
+            return value
+        if node_type == 'unary':
+            op, operand_node = node[1], node[2]
+            operand = cls._evaluate_node(operand_node, context)
+            number = cls._to_number(operand)
+            if op == '+':
+                return number
+            return -number
+        if node_type == 'binop':
+            op, left_node, right_node = node[1], node[2], node[3]
+            left = cls._evaluate_node(left_node, context)
+            right = cls._evaluate_node(right_node, context)
+            return cls._apply_operator(op, left, right)
+        if node_type == 'compare':
+            op, left_node, right_node = node[1], node[2], node[3]
+            left = cls._evaluate_node(left_node, context)
+            right = cls._evaluate_node(right_node, context)
+            return cls._apply_comparison(op, left, right)
+        if node_type == 'func':
+            func_name, args_nodes = node[1], node[2]
+            func = cls.FUNCTIONS.get(func_name)
+            if func is None:
+                raise FormulaError(f"Unknown function '{func_name}'.")
+            args = [cls._evaluate_node(arg, context) for arg in args_nodes]
+            try:
+                return cls._call_function(func, args, context)
+            except FormulaError:
+                raise
+            except Exception as exc:  # pragma: no cover - safety net
+                raise FormulaError(f"Error executing function '{func_name}': {exc}") from exc
+        raise FormulaError(f"Unsupported node type '{node_type}'.")
+
+    @classmethod
+    def _call_function(cls, func: Callable[..., Any], args: Sequence[Any], context: Mapping[str, Any]) -> Any:
+        signature = inspect.signature(func)
+        kwargs: Dict[str, Any] = {}
+        for param in signature.parameters.values():
+            if param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY):
+                if param.name == 'context':
+                    kwargs['context'] = context
+                elif param.name == 'engine':
+                    kwargs['engine'] = cls
+        return func(*args, **kwargs)
+
+    @staticmethod
+    def _to_number(value: Any) -> float:
+        if value is None:
+            return 0.0
+        if isinstance(value, bool):
+            return 1.0 if value else 0.0
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, Decimal):
+            return float(value)
+        if isinstance(value, (date, datetime)):
+            base = datetime.combine(date(1899, 12, 30), time())
+            delta = (value - base) if isinstance(value, datetime) else (datetime.combine(value, time()) - base)
+            return delta.days + delta.seconds / 86400
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped == '':
+                return 0.0
+            try:
+                return float(stripped) if any(c in stripped for c in '.eE') else float(int(stripped))
+            except ValueError as exc:
+                raise FormulaError(f"Cannot convert '{value}' to a number.") from exc
+        raise FormulaError(f"Unsupported value type '{type(value).__name__}' for numeric coercion.")
+
+    @staticmethod
+    def _apply_operator(op: str, left: Any, right: Any) -> Any:
+        if op == '&':
+            return ''.join(_flatten_text([left, right]))
+        left_num = FormulaEngine._to_number(left)
+        right_num = FormulaEngine._to_number(right)
+        if op == '+':
+            return FormulaEngine._normalize_number(left_num + right_num)
+        if op == '-':
+            return FormulaEngine._normalize_number(left_num - right_num)
+        if op == '*':
+            return FormulaEngine._normalize_number(left_num * right_num)
+        if op == '/':
+            if right_num == 0:
+                raise FormulaError("Division by zero.")
+            return FormulaEngine._normalize_number(left_num / right_num)
+        if op == '^':
+            return FormulaEngine._normalize_number(math.pow(left_num, right_num))
+        raise FormulaError(f"Unsupported operator '{op}'.")
+
+    @staticmethod
+    def _apply_comparison(op: str, left: Any, right: Any) -> bool:
+        left_cmp, left_is_num = _coerce_comparable(left)
+        right_cmp, right_is_num = _coerce_comparable(right)
+        if left_is_num and right_is_num:
+            left_value, right_value = left_cmp, right_cmp
+        else:
+            left_value, right_value = left_cmp, right_cmp
+        if op == '=':
+            return left_value == right_value
+        if op == '<>':
+            return left_value != right_value
+        if op == '>':
+            return left_value > right_value
+        if op == '>=':
+            return left_value >= right_value
+        if op == '<':
+            return left_value < right_value
+        if op == '<=':
+            return left_value <= right_value
+        raise FormulaError(f"Unsupported comparison operator '{op}'.")
+
+    @staticmethod
+    def _normalize_number(value: float) -> Any:
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        return value
+
+
+def _flatten(args: Iterable[Any]) -> Iterator[Any]:
+    for value in args:
+        if isinstance(value, (list, tuple)):
+            yield from _flatten(value)
+        else:
+            yield value
+
+
+def _flatten_text(args: Iterable[Any]) -> Iterator[str]:
+    for value in _flatten(args):
+        if value is None:
+            continue
+        yield str(value)
+
+
+def _coerce_comparable(value: Any) -> Tuple[Any, bool]:
+    try:
+        return FormulaEngine._to_number(value), True
+    except FormulaError:
+        if isinstance(value, (datetime, date, time)):
+            return value, False
+        if isinstance(value, bool):
+            return value, False
+        if value is None:
+            return '', False
+        return str(value), False
+
+
+def _round_half_up(number: Any, digits: int = 0) -> float:
+    decimal_value = Decimal(str(FormulaEngine._to_number(number)))
+    quantizer = Decimal('1').scaleb(-digits)
+    result = decimal_value.quantize(quantizer, rounding=ROUND_HALF_UP)
+    if digits <= 0:
+        return int(result)
+    return float(result)
+
+
+def _round_with_mode(number: Any, digits: int, mode: str) -> float:
+    number_value = FormulaEngine._to_number(number)
+    power = 10 ** digits
+    if digits >= 0:
+        scaled = number_value * power
+    else:
+        scaled = number_value / (10 ** (-digits))
+    if mode == 'up':
+        scaled = math.ceil(scaled) if scaled >= 0 else math.floor(scaled)
+    else:
+        scaled = math.floor(scaled) if scaled >= 0 else math.ceil(scaled)
+    if digits >= 0:
+        return scaled / power
+    return scaled * (10 ** (-digits))
+
+
+def _ensure_text(value: Any) -> str:
+    return '' if value is None else str(value)
+
+
+def _normalize_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime.combine(value, time())
+    if isinstance(value, time):
+        today = datetime.combine(date.today(), value)
+        return today
+    if isinstance(value, str):
+        text = value.strip()
+        for parse in (datetime.fromisoformat, _parse_date, _parse_time):
+            try:
+                parsed = parse(text)
+            except (ValueError, TypeError):
+                continue
+            if isinstance(parsed, datetime):
+                return parsed
+            if isinstance(parsed, date):
+                return datetime.combine(parsed, time())
+            if isinstance(parsed, time):
+                return datetime.combine(date.today(), parsed)
+    raise FormulaError(f"Cannot interpret '{value}' as a date/time value.")
+
+
+def _parse_date(text: str) -> date:
+    return date.fromisoformat(text)
+
+
+def _parse_time(text: str) -> time:
+    return time.fromisoformat(text)
+
+
+def _format_text(value: Any, fmt: str) -> str:
+    if isinstance(value, (datetime, date, time)):
+        dt = _normalize_datetime(value)
+        pattern = fmt
+        replacements = [
+            ('YYYY', '%Y'),
+            ('YY', '%y'),
+            ('MM', '%m'),
+            ('DD', '%d'),
+            ('HH', '%H'),
+            ('hh', '%I'),
+            ('mm', '%M'),
+            ('ss', '%S'),
+        ]
+        for token, repl in replacements:
+            pattern = pattern.replace(token, repl)
+        return dt.strftime(pattern)
+    try:
+        number = FormulaEngine._to_number(value)
+    except FormulaError:
+        try:
+            return fmt.format(value=value)
+        except Exception:
+            return _ensure_text(value)
+    if '#' in fmt or '0' in fmt:
+        if '.' in fmt:
+            decimals = len(fmt.split('.', 1)[1])
+            rounded = _round_half_up(number, decimals)
+            return f"{rounded:.{decimals}f}"
+        return str(_round_half_up(number, 0))
+    try:
+        return format(number, fmt)
+    except Exception:
+        return str(number)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip() != ''
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) > 0
+    return bool(value)
+
+
+def _is_blank(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ''
+    if isinstance(value, (list, tuple)):
+        return len(value) == 0
+    return False
+
+
+def _build_default_functions() -> Dict[str, Callable[..., Any]]:
+    def func_if(condition: Any, true_value: Any, false_value: Any = None) -> Any:
+        return true_value if _truthy(condition) else false_value
+
+    def func_ifs(*args: Any) -> Any:
+        if len(args) < 2 or len(args) % 2 != 0:
+            raise FormulaError("IFS requires condition/value pairs.")
+        for condition, value in zip(args[0::2], args[1::2]):
+            if _truthy(condition):
+                return value
+        raise FormulaError("IFS did not match any condition.")
+
+    def func_switch(expression: Any, *cases: Any) -> Any:
+        if not cases:
+            raise FormulaError("SWITCH requires at least one case.")
+        default = None
+        if len(cases) % 2 == 1:
+            default = cases[-1]
+            cases = cases[:-1]
+        for case, value in zip(cases[0::2], cases[1::2]):
+            if expression == case:
+                return value
+        if default is not None:
+            return default
+        raise FormulaError("SWITCH did not match any case.")
+
+    def func_sum(*args: Any) -> float:
+        total = 0.0
+        for value in _flatten(args):
+            total += FormulaEngine._to_number(value)
+        return FormulaEngine._normalize_number(total)
+
+    def func_average(*args: Any) -> float:
+        values = [FormulaEngine._to_number(value) for value in _flatten(args)]
+        if not values:
+            raise FormulaError("AVERAGE requires at least one numeric value.")
+        return FormulaEngine._normalize_number(sum(values) / len(values))
+
+    def func_min(*args: Any) -> Any:
+        values = [FormulaEngine._to_number(value) for value in _flatten(args)]
+        if not values:
+            raise FormulaError("MIN requires at least one numeric value.")
+        return FormulaEngine._normalize_number(min(values))
+
+    def func_max(*args: Any) -> Any:
+        values = [FormulaEngine._to_number(value) for value in _flatten(args)]
+        if not values:
+            raise FormulaError("MAX requires at least one numeric value.")
+        return FormulaEngine._normalize_number(max(values))
+
+    def func_round(number: Any, digits: Any = 0) -> float:
+        return _round_half_up(number, int(digits))
+
+    def func_roundup(number: Any, digits: Any = 0) -> float:
+        return _round_with_mode(number, int(digits), 'up')
+
+    def func_rounddown(number: Any, digits: Any = 0) -> float:
+        return _round_with_mode(number, int(digits), 'down')
+
+    def func_len(text: Any) -> int:
+        return len(_ensure_text(text))
+
+    def func_concat(*args: Any) -> str:
+        return ''.join(_flatten_text(args))
+
+    def func_lower(text: Any) -> str:
+        return _ensure_text(text).lower()
+
+    def func_upper(text: Any) -> str:
+        return _ensure_text(text).upper()
+
+    def func_proper(text: Any) -> str:
+        return ' '.join(word.capitalize() for word in _ensure_text(text).split())
+
+    def func_trim(text: Any) -> str:
+        return ' '.join(_ensure_text(text).split())
+
+    def func_substitute(text: Any, old: Any, new: Any, occurrence: Any = None) -> str:
+        source = _ensure_text(text)
+        old_text = _ensure_text(old)
+        new_text = _ensure_text(new)
+        if occurrence is None:
+            return source.replace(old_text, new_text)
+        index = int(occurrence)
+        if index <= 0:
+            return source
+        parts = source.split(old_text)
+        if len(parts) <= index:
+            return source
+        rebuilt: List[str] = []
+        for i, part in enumerate(parts[:-1], start=1):
+            rebuilt.append(part)
+            if i == index:
+                rebuilt.append(new_text)
+            else:
+                rebuilt.append(old_text)
+        rebuilt.append(parts[-1])
+        return ''.join(rebuilt)
+
+    def func_replace(text: Any, start: Any, length: Any, new_text: Any) -> str:
+        source = _ensure_text(text)
+        start_index = max(int(start) - 1, 0)
+        count = max(int(length), 0)
+        return source[:start_index] + _ensure_text(new_text) + source[start_index + count :]
+
+    def func_left(text: Any, count: Any = 1) -> str:
+        source = _ensure_text(text)
+        return source[: max(int(count), 0)]
+
+    def func_right(text: Any, count: Any = 1) -> str:
+        source = _ensure_text(text)
+        length = max(int(count), 0)
+        if length == 0:
+            return ''
+        return source[-length:]
+
+    def func_mid(text: Any, start: Any, length: Any) -> str:
+        source = _ensure_text(text)
+        start_index = max(int(start) - 1, 0)
+        end_index = start_index + max(int(length), 0)
+        return source[start_index:end_index]
+
+    def func_search(needle: Any, haystack: Any, start: Any = 1) -> int:
+        text = _ensure_text(haystack).lower()
+        target = _ensure_text(needle).lower()
+        position = text.find(target, max(int(start) - 1, 0))
+        if position == -1:
+            raise FormulaError("SEARCH could not find the specified text.")
+        return position + 1
+
+    def func_find(needle: Any, haystack: Any, start: Any = 1) -> int:
+        text = _ensure_text(haystack)
+        target = _ensure_text(needle)
+        position = text.find(target, max(int(start) - 1, 0))
+        if position == -1:
+            raise FormulaError("FIND could not find the specified text.")
+        return position + 1
+
+    def func_split(text: Any, delimiter: Any) -> List[str]:
+        return _ensure_text(text).split(_ensure_text(delimiter))
+
+    def func_value(text: Any) -> float:
+        return FormulaEngine._to_number(text)
+
+    def func_to_text(value: Any) -> str:
+        return _ensure_text(value)
+
+    def func_text(value: Any, fmt: Any) -> str:
+        return _format_text(value, _ensure_text(fmt))
+
+    def func_now() -> datetime:
+        return datetime.now()
+
+    def func_today() -> date:
+        return date.today()
+
+    def func_date(year: Any, month: Any, day: Any) -> date:
+        return date(int(year), int(month), int(day))
+
+    def func_time(hour: Any, minute: Any, second: Any = 0) -> time:
+        return time(int(hour), int(minute), int(second))
+
+    def func_year(value: Any) -> int:
+        return _normalize_datetime(value).year
+
+    def func_month(value: Any) -> int:
+        return _normalize_datetime(value).month
+
+    def func_day(value: Any) -> int:
+        return _normalize_datetime(value).day
+
+    def func_hour(value: Any) -> int:
+        return _normalize_datetime(value).hour
+
+    def func_minute(value: Any) -> int:
+        return _normalize_datetime(value).minute
+
+    def func_second(value: Any) -> int:
+        return _normalize_datetime(value).second
+
+    def func_and(*args: Any) -> bool:
+        return all(_truthy(value) for value in args)
+
+    def func_or(*args: Any) -> bool:
+        return any(_truthy(value) for value in args)
+
+    def func_not(value: Any) -> bool:
+        return not _truthy(value)
+
+    def func_isnumber(value: Any) -> bool:
+        try:
+            FormulaEngine._to_number(value)
+        except FormulaError:
+            return False
+        return True
+
+    def func_istext(value: Any) -> bool:
+        return isinstance(value, str)
+
+    def func_isblank(value: Any) -> bool:
+        return _is_blank(value)
+
+    functions: Dict[str, Callable[..., Any]] = {
+        'IF': func_if,
+        'IFS': func_ifs,
+        'SWITCH': func_switch,
+        'SUM': func_sum,
+        'AVERAGE': func_average,
+        'MIN': func_min,
+        'MAX': func_max,
+        'ROUND': func_round,
+        'ROUNDUP': func_roundup,
+        'ROUNDDOWN': func_rounddown,
+        'LEN': func_len,
+        'CONCAT': func_concat,
+        'CONCATENATE': func_concat,
+        'LOWER': func_lower,
+        'UPPER': func_upper,
+        'PROPER': func_proper,
+        'TRIM': func_trim,
+        'SUBSTITUTE': func_substitute,
+        'REPLACE': func_replace,
+        'LEFT': func_left,
+        'RIGHT': func_right,
+        'MID': func_mid,
+        'SEARCH': func_search,
+        'FIND': func_find,
+        'SPLIT': func_split,
+        'VALUE': func_value,
+        'TO_TEXT': func_to_text,
+        'TEXT': func_text,
+        'NOW': func_now,
+        'TODAY': func_today,
+        'DATE': func_date,
+        'TIME': func_time,
+        'YEAR': func_year,
+        'MONTH': func_month,
+        'DAY': func_day,
+        'HOUR': func_hour,
+        'MINUTE': func_minute,
+        'SECOND': func_second,
+        'AND': func_and,
+        'OR': func_or,
+        'NOT': func_not,
+        'ISNUMBER': func_isnumber,
+        'ISTEXT': func_istext,
+        'ISBLANK': func_isblank,
+    }
+    return functions
+
+
+FormulaEngine.FUNCTIONS.update(_build_default_functions())
+

--- a/main.py
+++ b/main.py
@@ -1,18 +1,134 @@
 # -*- coding: utf-8 -*-
 import os
+import csv
 import json
 import re
 import sqlite3
+import sys
 import time
+
+APP_TITLE = "Prom Generator"
+from copy import deepcopy
 from datetime import datetime
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
-import customtkinter as ctk
-import pandas as pd
-from jinja2 import Template, TemplateError
+from formula_engine import FormulaEngine, FormulaError
 
-APP_TITLE = "Prom Generator"
+
+def _show_dependency_error(message: str) -> None:
+    """Display a blocking error for a missing runtime dependency."""
+
+    root = None
+    try:
+        root = tk.Tk()
+        root.withdraw()
+        messagebox.showerror(APP_TITLE, message)
+    except Exception:
+        print(message, file=sys.stderr)
+    finally:
+        if root is not None:
+            try:
+                root.destroy()
+            except Exception:
+                pass
+
+
+DEPENDENCY_WARNINGS = []
+
+CSV_JSON_FALLBACK_NOTE = "\nЕкспорт у CSV (.csv) та JSON (.json) залишається доступним."
+PANDAS_INSTALL_HINT = (
+    "Встановіть бібліотеку командою 'pip install pandas' і перезапустіть застосунок, щоб увімкнути цей формат."
+)
+OPENPYXL_INSTALL_HINT = (
+    "Встановіть бібліотеку командою 'pip install openpyxl' і перезапустіть застосунок, щоб увімкнути цей формат."
+)
+
+try:
+    import customtkinter as ctk
+except ModuleNotFoundError:
+    _show_dependency_error(
+        "Бібліотека CustomTkinter не знайдена.\n"
+        "Встановіть її командою 'pip install customtkinter' і перезапустіть застосунок."
+    )
+    sys.exit(1)
+
+PANDAS_IMPORT_ERROR_DETAIL = ""
+PANDAS_EXPORT_BLOCKED_MESSAGE = ""
+EXCEL_ENGINE_IMPORT_ERROR_DETAIL = ""
+EXCEL_EXPORT_BLOCKED_MESSAGE = ""
+
+try:
+    import pandas as pd
+except ModuleNotFoundError as exc:
+    pd = None
+    PANDAS_IMPORT_ERROR_DETAIL = str(exc)
+    PANDAS_EXPORT_BLOCKED_MESSAGE = (
+        "Експорт у формат Excel (.xlsx) недоступний: бібліотека pandas не встановлена."
+    )
+except ImportError as exc:  # e.g. missing binary dependencies
+    pd = None
+    PANDAS_IMPORT_ERROR_DETAIL = str(exc)
+    PANDAS_EXPORT_BLOCKED_MESSAGE = (
+        "Експорт у формат Excel (.xlsx) недоступний: не вдалося завантажити бібліотеку pandas."
+    )
+else:
+    PANDAS_IMPORT_ERROR_DETAIL = ""
+    PANDAS_EXPORT_BLOCKED_MESSAGE = ""
+
+if PANDAS_EXPORT_BLOCKED_MESSAGE:
+    detail_suffix = f"\nДеталі: {PANDAS_IMPORT_ERROR_DETAIL}" if PANDAS_IMPORT_ERROR_DETAIL else ""
+    DEPENDENCY_WARNINGS.append(
+        PANDAS_EXPORT_BLOCKED_MESSAGE
+        + detail_suffix
+        + "\n"
+        + PANDAS_INSTALL_HINT
+        + CSV_JSON_FALLBACK_NOTE
+    )
+else:
+    PANDAS_IMPORT_ERROR_DETAIL = ""
+
+if pd is None:
+    EXCEL_EXPORT_BLOCKED_MESSAGE = PANDAS_EXPORT_BLOCKED_MESSAGE
+else:
+    try:
+        import openpyxl  # noqa: F401  # type: ignore[import-not-found]
+    except ModuleNotFoundError as exc:
+        EXCEL_ENGINE_IMPORT_ERROR_DETAIL = str(exc)
+        EXCEL_EXPORT_BLOCKED_MESSAGE = (
+            "Експорт у формат Excel (.xlsx) недоступний: бібліотека openpyxl не встановлена."
+        )
+    except ImportError as exc:
+        EXCEL_ENGINE_IMPORT_ERROR_DETAIL = str(exc)
+        EXCEL_EXPORT_BLOCKED_MESSAGE = (
+            "Експорт у формат Excel (.xlsx) недоступний: не вдалося завантажити бібліотеку openpyxl."
+        )
+
+if EXCEL_EXPORT_BLOCKED_MESSAGE and pd is not None:
+    detail_suffix = (
+        f"\nДеталі: {EXCEL_ENGINE_IMPORT_ERROR_DETAIL}"
+        if EXCEL_ENGINE_IMPORT_ERROR_DETAIL
+        else ""
+    )
+    DEPENDENCY_WARNINGS.append(
+        EXCEL_EXPORT_BLOCKED_MESSAGE
+        + detail_suffix
+        + "\n"
+        + OPENPYXL_INSTALL_HINT
+        + CSV_JSON_FALLBACK_NOTE
+    )
+else:
+    EXCEL_ENGINE_IMPORT_ERROR_DETAIL = ""
+
+try:
+    from jinja2 import Template, TemplateError
+except ModuleNotFoundError:
+    _show_dependency_error(
+        "Бібліотека Jinja2 не знайдена.\n"
+        "Встановіть її командою 'pip install jinja2' і перезапустіть застосунок."
+    )
+    sys.exit(1)
+
 DB_FILE = "catalog.db"
 TEMPLATES_FILE = "templates.json"
 EXPORT_FIELDS_FILE = "export_fields.json"
@@ -110,6 +226,17 @@ DEFAULT_EXPORT_FIELDS = [
     {"field": "Значення_Характеристики", "enabled": False, "template": "{{ spec_items | map(attribute=1) | join('; ') }}"},
 ]
 
+EXCEL_FORMAT_LABEL = "Excel (.xlsx)"
+CSV_FORMAT_LABEL = "CSV (.csv)"
+JSON_FORMAT_LABEL = "JSON (.json)"
+EXPORT_FORMAT_OPTIONS = (EXCEL_FORMAT_LABEL, CSV_FORMAT_LABEL, JSON_FORMAT_LABEL)
+
+
+def get_available_export_formats():
+    if pd is None or EXCEL_EXPORT_BLOCKED_MESSAGE:
+        return [fmt for fmt in EXPORT_FORMAT_OPTIONS if fmt != EXCEL_FORMAT_LABEL]
+    return list(EXPORT_FORMAT_OPTIONS)
+
 def _title_tags_block(title: str, tags: str) -> dict:
     return {
         "title_template": title,
@@ -125,15 +252,27 @@ def _build_title_tags_defaults(film_type_names, base_title, base_tags):
 
 def load_templates():
     if not os.path.exists(TEMPLATES_FILE):
-        with open(TEMPLATES_FILE, "w", encoding="utf-8") as f:
-            json.dump(DEFAULT_TEMPLATES, f, ensure_ascii=False, indent=2)
-        return DEFAULT_TEMPLATES.copy()
-    with open(TEMPLATES_FILE, "r", encoding="utf-8") as f:
-        data = json.load(f)
+        defaults = deepcopy(DEFAULT_TEMPLATES)
+        save_templates(defaults)
+        return defaults
+
+    try:
+        with open(TEMPLATES_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        defaults = deepcopy(DEFAULT_TEMPLATES)
+        save_templates(defaults)
+        return defaults
+
+    if not isinstance(data, dict):
+        defaults = deepcopy(DEFAULT_TEMPLATES)
+        save_templates(defaults)
+        return defaults
+
     # гарантуємо всі ключі
     for k, v in DEFAULT_TEMPLATES.items():
         if k not in data:
-            data[k] = v
+            data[k] = deepcopy(v)
     return data
 
 def save_templates(dct):
@@ -578,6 +717,153 @@ def load_specs_map(model_ids):
         specs_map.setdefault(model_id, {})[key] = value
     return specs_map
 
+# ============================ ФОРМУЛИ ============================
+
+_FORMULA_PREFIX_RE = re.compile(r"^\s*=")
+_IDENTIFIER_SANITIZE_RE = re.compile(r"[^\w]+", re.UNICODE)
+_ASCII_SANITIZE_RE = re.compile(r"[^0-9a-z]+")
+
+_TRANSLIT_TABLE = {
+    "а": "a",
+    "б": "b",
+    "в": "v",
+    "г": "h",
+    "ґ": "g",
+    "д": "d",
+    "е": "e",
+    "є": "ie",
+    "ж": "zh",
+    "з": "z",
+    "и": "y",
+    "і": "i",
+    "ї": "yi",
+    "й": "y",
+    "к": "k",
+    "л": "l",
+    "м": "m",
+    "н": "n",
+    "о": "o",
+    "п": "p",
+    "р": "r",
+    "с": "s",
+    "т": "t",
+    "у": "u",
+    "ф": "f",
+    "х": "kh",
+    "ц": "ts",
+    "ч": "ch",
+    "ш": "sh",
+    "щ": "shch",
+    "ь": "",
+    "ю": "yu",
+    "я": "ya",
+    "ъ": "",
+    "ы": "y",
+    "э": "e",
+    "ё": "yo",
+}
+
+_COMMON_SPEC_ALIAS = {
+    "color": "color",
+    "colour": "color",
+    "kolir": "color",
+    "колір": "color",
+    "цвет": "color",
+    "brand": "brand",
+    "бренд": "brand",
+    "weight": "weight",
+    "вага": "weight",
+    "вес": "weight",
+    "material": "material",
+    "матеріал": "material",
+    "материал": "material",
+    "thickness": "thickness",
+    "товщина": "thickness",
+    "толщина": "thickness",
+    "sku": "sku",
+    "код": "sku",
+    "код_товару": "sku",
+}
+
+
+def _looks_like_formula(text: str) -> bool:
+    return bool(text) and bool(_FORMULA_PREFIX_RE.match(text))
+
+
+def _normalize_identifier(value: str) -> str:
+    lowered = value.strip().lower()
+    cleaned = _IDENTIFIER_SANITIZE_RE.sub("_", lowered)
+    cleaned = re.sub(r"_+", "_", cleaned).strip("_")
+    return cleaned
+
+
+def _transliterate_ascii(value: str) -> str:
+    result = []
+    for ch in value.lower():
+        if ch.isdigit():
+            result.append(ch)
+            continue
+        if "a" <= ch <= "z":
+            result.append(ch)
+            continue
+        if ch in _TRANSLIT_TABLE:
+            result.append(_TRANSLIT_TABLE[ch])
+            continue
+        if ch == "_" or ch.isspace():
+            result.append("_")
+        else:
+            result.append("")
+    ascii_candidate = "".join(result)
+    ascii_candidate = _ASCII_SANITIZE_RE.sub("_", ascii_candidate)
+    ascii_candidate = re.sub(r"_+", "_", ascii_candidate).strip("_")
+    return ascii_candidate
+
+
+def _build_formula_context(base_context):
+    formula_context = {}
+    for key, value in base_context.items():
+        if callable(value):
+            continue
+        formula_context[key] = value
+
+    if "brand" in base_context and "attr_brand" not in formula_context:
+        formula_context["attr_brand"] = base_context.get("brand")
+    if "model" in base_context and "attr_model" not in formula_context:
+        formula_context["attr_model"] = base_context.get("model")
+
+    specs = base_context.get("specs")
+    if isinstance(specs, dict):
+        for spec_key, spec_value in specs.items():
+            if spec_value is None:
+                continue
+            key_str = str(spec_key)
+            normalized = _normalize_identifier(key_str)
+            ascii_name = _transliterate_ascii(key_str)
+            for candidate in (normalized, ascii_name):
+                if candidate:
+                    formula_context.setdefault(f"attr_{candidate}", spec_value)
+            alias_source = None
+            if ascii_name and ascii_name in _COMMON_SPEC_ALIAS:
+                alias_source = _COMMON_SPEC_ALIAS[ascii_name]
+            elif normalized and normalized in _COMMON_SPEC_ALIAS:
+                alias_source = _COMMON_SPEC_ALIAS[normalized]
+            if alias_source:
+                formula_context.setdefault(f"attr_{alias_source}", spec_value)
+
+    category_name = base_context.get("category")
+    if isinstance(category_name, str):
+        cat_slug = _transliterate_ascii(category_name) or _normalize_identifier(category_name)
+        if cat_slug:
+            formula_context.setdefault(f"category_{cat_slug}", category_name)
+
+    film_type = base_context.get("film_type")
+    if isinstance(film_type, str):
+        ft_slug = _transliterate_ascii(film_type) or _normalize_identifier(film_type)
+        if ft_slug:
+            formula_context.setdefault(f"film_type_{ft_slug}", film_type)
+
+    return formula_context
+
 # ============================ ГЕНЕРАЦІЯ ============================
 
 def _normalize_id_list(ids):
@@ -651,7 +937,9 @@ def generate_export_rows(
     category_ids=None,
     brand_ids=None,
     model_ids=None,
+    progress_callback=None,
 ):
+    film_types = list(film_types)
     pairs = collect_models(category_ids=category_ids, brand_ids=brand_ids, model_ids=model_ids)
     if not pairs:
         return [], []
@@ -684,6 +972,11 @@ def generate_export_rows(
     column_order = [field["field"] for field in enabled_fields]
 
     descriptions = templates.get("descriptions", {})
+
+    total_steps = len(pairs) * len(film_types)
+    progress_count = 0
+    if progress_callback is not None:
+        progress_callback(progress_count, total_steps)
 
     for brand, model, cat, mid, brand_id, cat_id in pairs:
         specs = specs_map.get(mid, {})
@@ -757,25 +1050,36 @@ def generate_export_rows(
             }
 
             record = {}
+            formula_context = None
             for field in enabled_fields:
                 field_name = field["field"]
                 tpl_str = field.get("template", "")
                 if tpl_str:
-                    tpl = field_template_cache.get(tpl_str)
-                    if tpl is None:
+                    if _looks_like_formula(tpl_str):
+                        if formula_context is None:
+                            formula_context = _build_formula_context(context)
                         try:
-                            tpl = Template(tpl_str)
+                            value = FormulaEngine.evaluate(tpl_str, formula_context)
+                        except FormulaError as exc:
+                            raise ValueError(
+                                f"Помилка у формулі поля \"{field_name}\": {exc}"
+                            ) from exc
+                    else:
+                        tpl = field_template_cache.get(tpl_str)
+                        if tpl is None:
+                            try:
+                                tpl = Template(tpl_str)
+                            except TemplateError as exc:
+                                raise ValueError(
+                                    f"Помилка в шаблоні поля \"{field_name}\": {exc}"
+                                ) from exc
+                            field_template_cache[tpl_str] = tpl
+                        try:
+                            value = tpl.render(**context)
                         except TemplateError as exc:
                             raise ValueError(
-                                f"Помилка в шаблоні поля \"{field_name}\": {exc}"
+                                f"Не вдалося згенерувати значення поля \"{field_name}\": {exc}"
                             ) from exc
-                        field_template_cache[tpl_str] = tpl
-                    try:
-                        value = tpl.render(**context)
-                    except TemplateError as exc:
-                        raise ValueError(
-                            f"Не вдалося згенерувати значення поля \"{field_name}\": {exc}"
-                        ) from exc
                 else:
                     value = context.get(field_name, "")
                 if value is None:
@@ -784,6 +1088,9 @@ def generate_export_rows(
                     value = str(value)
                 record[field_name] = value
             rows.append(record)
+            progress_count += 1
+            if progress_callback is not None:
+                progress_callback(progress_count, total_steps)
 
     return rows, column_order
 
@@ -792,16 +1099,53 @@ def export_products(records: list, columns: list, fmt: str, folder: str):
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     base = os.path.join(folder, f"products_{ts}")
 
-    if fmt == "Excel (.xlsx)":
+    if fmt == EXCEL_FORMAT_LABEL:
+        if pd is None or EXCEL_EXPORT_BLOCKED_MESSAGE:
+            if pd is None:
+                message = PANDAS_EXPORT_BLOCKED_MESSAGE or "Експорт у Excel недоступний."
+                detail = PANDAS_IMPORT_ERROR_DETAIL
+                install_hint = PANDAS_INSTALL_HINT
+            else:
+                message = EXCEL_EXPORT_BLOCKED_MESSAGE or "Експорт у Excel недоступний."
+                detail = EXCEL_ENGINE_IMPORT_ERROR_DETAIL
+                install_hint = OPENPYXL_INSTALL_HINT
+            if detail and detail not in message:
+                message = f"{message} (деталі: {detail})"
+            message = f"{message}\n{install_hint}{CSV_JSON_FALLBACK_NOTE}"
+            raise RuntimeError(message)
         out_products = base + ".xlsx"
-        pd.DataFrame.from_records(records, columns=columns).to_excel(out_products, index=False)
-    elif fmt == "CSV (.csv)":
+        df = pd.DataFrame.from_records(records, columns=columns)
+        try:
+            df.to_excel(out_products, index=False)
+        except (ImportError, ModuleNotFoundError) as exc:
+            exc_text = str(exc)
+            if "openpyxl" in exc_text.lower():
+                message = (
+                    "Не вдалося зберегти Excel-файл: бібліотека openpyxl не встановлена або пошкоджена.\n"
+                    "Встановіть її командою 'pip install openpyxl' і перезапустіть застосунок, або оберіть інший формат експорту."
+                )
+                raise RuntimeError(message) from exc
+            raise
+    elif fmt == CSV_FORMAT_LABEL:
         out_products = base + ".csv"
-        pd.DataFrame.from_records(records, columns=columns).to_csv(out_products, index=False, encoding="utf-8-sig")
-    else:
+        if pd is not None:
+            pd.DataFrame.from_records(records, columns=columns).to_csv(
+                out_products, index=False, encoding="utf-8-sig"
+            )
+        else:
+            with open(out_products, "w", newline="", encoding="utf-8-sig") as f:
+                writer = csv.writer(f)
+                if columns:
+                    writer.writerow(columns)
+                for record in records:
+                    row = [record.get(col, "") for col in columns]
+                    writer.writerow(row)
+    elif fmt == JSON_FORMAT_LABEL:
         out_products = base + ".json"
         with open(out_products, "w", encoding="utf-8") as f:
             json.dump(records, f, ensure_ascii=False, indent=2)
+    else:
+        raise ValueError(f"Невідомий формат експорту: {fmt}")
 
     return out_products
 
@@ -1024,6 +1368,8 @@ class App(ctk.CTk):
         self._rename_delay_max = 4.0
         self._export_selected_index = None
         self._export_tree_updating = False
+        self.progress_bar = None
+        self.progress_label = None
 
         self._build_header()
         self._build_tabs()
@@ -1031,6 +1377,9 @@ class App(ctk.CTk):
         # Початкові дані
         self._refresh_categories()
         self._refresh_filmtype_checkboxes()
+
+        if DEPENDENCY_WARNINGS:
+            self.after(200, self._show_dependency_warnings)
 
     # -------- верхній бар
     def _build_header(self):
@@ -1058,6 +1407,11 @@ class App(ctk.CTk):
         self._build_tab_templates()
         self._build_tab_export()
         self._build_tab_generate()
+
+    def _show_dependency_warnings(self):
+        for warning in DEPENDENCY_WARNINGS:
+            messagebox.showwarning(APP_TITLE, warning)
+        DEPENDENCY_WARNINGS.clear()
 
     def _film_type_names(self):
         return [item.get("name") for item in self.templates.get("film_types", []) if item.get("name")]
@@ -1662,17 +2016,30 @@ class App(ctk.CTk):
         )
         self.export_field_enabled_check.pack(anchor="w", padx=10, pady=(0, 8))
 
-        ctk.CTkLabel(detail, text="Шаблон (Jinja2)").pack(anchor="w", padx=10, pady=(0, 4))
+        ctk.CTkLabel(detail, text="Шаблон (формула =IF(...) або Jinja2)").pack(anchor="w", padx=10, pady=(0, 4))
         self.export_field_template = ctk.CTkTextbox(detail, height=220)
-        self.export_field_template.pack(fill="both", expand=True, padx=10, pady=(0, 8))
+        self.export_field_template.pack(fill="both", expand=True, padx=10, pady=(0, 6))
+        self.export_field_template.bind("<<Modified>>", self._on_export_template_modified)
 
         hint_text = (
-            "Доступні змінні: {{ brand }}, {{ model }}, {{ category }}, {{ film_type }}, {{ title }}, {{ description }}, {{ tags }}, "
-            "{{ spec('Назва') }}, {{ specs['Ключ'] }}, {{ row_number }}, {{ now }}."
+            "Почніть рядок зі знаком '=' щоб використати формулу у стилі Google Sheets (аргументи через ';').\n"
+            "Без '=' шаблон рендериться через Jinja2. Доступні змінні: {{ brand }}, {{ model }}, {{ category }}, {{ film_type }}, "
+            "{{ title }}, {{ description }}, {{ tags }}, {{ spec('Назва') }}, {{ specs['Ключ'] }}, {{ row_number }}, {{ now }}."
         )
         ctk.CTkLabel(detail, text=hint_text, justify="left", anchor="w", wraplength=360).pack(
-            fill="x", padx=10, pady=(0, 8)
+            fill="x", padx=10, pady=(0, 4)
         )
+
+        self.export_template_status = ctk.CTkLabel(
+            detail,
+            text="",
+            justify="left",
+            anchor="w",
+            wraplength=360,
+            text_color="#888888",
+        )
+        self.export_template_status.pack(fill="x", padx=10, pady=(0, 8))
+        self._update_template_status("")
 
         action_row = ctk.CTkFrame(detail)
         action_row.pack(fill="x", padx=10, pady=(0, 10))
@@ -1713,6 +2080,7 @@ class App(ctk.CTk):
             self.export_apply_button.configure(state=state)
         if hasattr(self, "export_field_template"):
             self.export_field_template.configure(state="normal" if enabled else "disabled")
+        self._update_template_status()
 
     def _load_export_field_detail(self, index):
         if index is None or index < 0 or index >= len(self.export_fields):
@@ -1726,6 +2094,7 @@ class App(ctk.CTk):
                 self.export_field_template.configure(state="normal")
                 self.export_field_template.delete("1.0", "end")
                 self.export_field_template.configure(state="disabled")
+            self._update_template_status("")
             return
 
         self._export_selected_index = index
@@ -1742,6 +2111,8 @@ class App(ctk.CTk):
         self.export_field_template.configure(state="normal")
         self.export_field_template.delete("1.0", "end")
         self.export_field_template.insert("1.0", str(template))
+        self.export_field_template.edit_modified(False)
+        self._update_template_status(template)
 
     def _on_export_field_select(self, _event):
         if getattr(self, "_export_tree_updating", False):
@@ -1761,6 +2132,64 @@ class App(ctk.CTk):
         else:
             self._load_export_field_detail(idx)
 
+    def _on_export_template_modified(self, _event):
+        widget = getattr(self, "export_field_template", None)
+        if widget is None:
+            return
+        try:
+            modified = bool(widget.edit_modified())
+        except Exception:
+            modified = True
+        if not modified:
+            return
+        try:
+            widget.edit_modified(False)
+        except Exception:
+            pass
+        text = widget.get("1.0", "end").rstrip()
+        self._update_template_status(text)
+
+    def _update_template_status(self, template_text: str | None = None):
+        label = getattr(self, "export_template_status", None)
+        if label is None:
+            return
+        if template_text is None:
+            widget = getattr(self, "export_field_template", None)
+            if widget is None:
+                template_text = ""
+            else:
+                template_text = widget.get("1.0", "end").rstrip()
+        message, color = self._analyze_template_text(template_text)
+        label.configure(text=message, text_color=color)
+
+    def _analyze_template_text(self, template_text: str):
+        trimmed = template_text.strip()
+        if not trimmed:
+            return (
+                "Введіть формулу (=IF(...)) або шаблон Jinja2. Аргументи формули розділяйте ';'.",
+                "#888888",
+            )
+        if _looks_like_formula(trimmed):
+            try:
+                info = FormulaEngine.describe(trimmed)
+            except FormulaError as exc:
+                return (f"❌ Помилка формули: {exc}", "#c94a4a")
+            variables = sorted(info.get("variables", []))
+            if variables:
+                vars_text = ", ".join(variables)
+                hint = f"Змінні: {vars_text}"
+            else:
+                hint = "Змінні не використовуються."
+            return (f"✅ Формула валідна. {hint}", "#4c9a2a")
+        try:
+            Template(trimmed)
+        except TemplateError as exc:
+            return (f"❌ Помилка шаблону Jinja2: {exc}", "#c94a4a")
+        return (
+            "ℹ️ Використовується шаблон Jinja2. Доступні змінні: {{ brand }}, {{ model }}, {{ category }}, {{ film_type }}, {{ title }}, {{ description }}, {{ tags }}, {{ row_number }}, {{ now }}.",
+            "#888888",
+        )
+
     def _export_apply_detail(self, save_to_file: bool):
         idx = getattr(self, "_export_selected_index", None)
         if idx is None or idx < 0 or idx >= len(self.export_fields):
@@ -1773,6 +2202,23 @@ class App(ctk.CTk):
         template = self.export_field_template.get("1.0", "end").rstrip()
         enabled = bool(self.export_field_enabled_var.get())
 
+        trimmed_template = template.strip()
+        if trimmed_template:
+            if _looks_like_formula(trimmed_template):
+                try:
+                    FormulaEngine.describe(trimmed_template)
+                except FormulaError as exc:
+                    show_error(f"Помилка у формулі: {exc}")
+                    self._update_template_status(template)
+                    return False
+            else:
+                try:
+                    Template(trimmed_template)
+                except TemplateError as exc:
+                    show_error(f"Помилка у шаблоні Jinja2: {exc}")
+                    self._update_template_status(template)
+                    return False
+
         changed = False
         if field.get("field") != name:
             field["field"] = name
@@ -1783,6 +2229,8 @@ class App(ctk.CTk):
         if bool(field.get("enabled")) != enabled:
             field["enabled"] = enabled
             changed = True
+
+        self._update_template_status(template)
 
         if changed:
             self._refresh_export_fields_tree(select_index=idx)
@@ -1896,10 +2344,14 @@ class App(ctk.CTk):
         fmt_frame = ctk.CTkFrame(right)
         fmt_frame.pack(fill="x", padx=10, pady=(6, 6))
         ctk.CTkLabel(fmt_frame, text="Формат експорту:").pack(anchor="w", padx=6, pady=(4, 4))
-        self.export_fmt_var = tk.StringVar(value="Excel (.xlsx)")
+        export_formats = get_available_export_formats()
+        if not export_formats:
+            export_formats = ["JSON (.json)"]
+        default_format = export_formats[0]
+        self.export_fmt_var = tk.StringVar(value=default_format)
         self.export_fmt_menu = ctk.CTkOptionMenu(
             fmt_frame,
-            values=["Excel (.xlsx)", "CSV (.csv)", "JSON (.json)"],
+            values=export_formats,
             variable=self.export_fmt_var,
             width=200,
         )
@@ -1924,7 +2376,66 @@ class App(ctk.CTk):
         action_row.pack(fill="x", padx=10, pady=(6, 0))
         ctk.CTkButton(action_row, text="Згенерувати", command=self._generate, height=36).pack(side="right", padx=6)
 
+        progress_frame = ctk.CTkFrame(right)
+        progress_frame.pack(fill="x", padx=10, pady=(10, 0))
+        self.progress_bar = ctk.CTkProgressBar(progress_frame)
+        self.progress_bar.pack(fill="x", padx=6, pady=(6, 4))
+        self.progress_bar.set(0)
+        self.progress_label = ctk.CTkLabel(progress_frame, text="Очікування", anchor="w")
+        self.progress_label.pack(fill="x", padx=6, pady=(0, 6))
+
         self._reload_gen_tree()
+
+    def _progress_reset(self, message: str = "Очікування"):
+        bar = getattr(self, "progress_bar", None)
+        if bar is None:
+            return
+        if hasattr(bar, "stop"):
+            bar.stop()
+        bar.configure(mode="determinate")
+        bar.set(0)
+        label = getattr(self, "progress_label", None)
+        if label is not None and message is not None:
+            label.configure(text=message)
+        self.update_idletasks()
+
+    def _progress_update(self, current: int, total: int, stage: str = "Генерація"):
+        bar = getattr(self, "progress_bar", None)
+        if bar is None:
+            return
+        total = total or 0
+        if total > 0:
+            fraction = max(0.0, min(float(current) / float(total), 1.0))
+        else:
+            fraction = 0.0
+        bar.configure(mode="determinate")
+        bar.set(fraction)
+        label = getattr(self, "progress_label", None)
+        if label is not None:
+            if total > 0:
+                text = f"{stage}: {current} з {total}"
+            else:
+                text = f"{stage}: {current}"
+            label.configure(text=text)
+        self.update_idletasks()
+
+    def _progress_message(self, message: str):
+        label = getattr(self, "progress_label", None)
+        if label is not None and message is not None:
+            label.configure(text=message)
+        self.update_idletasks()
+
+    def _progress_finish(self, message: str = "Готово"):
+        bar = getattr(self, "progress_bar", None)
+        if bar is not None:
+            if hasattr(bar, "stop"):
+                bar.stop()
+            bar.configure(mode="determinate")
+            bar.set(1)
+        label = getattr(self, "progress_label", None)
+        if label is not None and message is not None:
+            label.configure(text=message)
+        self.update_idletasks()
 
     def _reload_gen_tree(self):
         tree = getattr(self, "_gen_tree", None)
@@ -2130,12 +2641,14 @@ class App(ctk.CTk):
         if folder: self.out_folder_var.set(folder)
 
     def _generate(self):
+        self._progress_reset("Підготовка...")
         # зберегти (на випадок якщо змінювали шаблони перед тим)
         self._save_title_tags(show_message=False)
         self._export_apply_detail(save_to_file=False)
 
         selected_types = [name for name, var in self.ft_vars if var.get()]
         if not selected_types:
+            self._progress_reset("Очікування")
             return show_error("Оберіть хоча б один тип плівки.")
 
         # оновимо enabled у файлі шаблонів
@@ -2148,6 +2661,11 @@ class App(ctk.CTk):
 
         # вибір моделей через дерево
         selected_models = sorted(self._collect_checked_model_ids())
+        self._progress_message("Генерація даних...")
+
+        def progress_callback(current, total):
+            self._progress_update(current, total, stage="Генерація")
+
         try:
             if selected_models:
                 records, columns = generate_export_rows(
@@ -2156,6 +2674,7 @@ class App(ctk.CTk):
                     self.title_tags_templates,
                     self.export_fields,
                     model_ids=selected_models,
+                    progress_callback=progress_callback,
                 )
             else:
                 records, columns = generate_export_rows(
@@ -2163,14 +2682,18 @@ class App(ctk.CTk):
                     self.templates,
                     self.title_tags_templates,
                     self.export_fields,
+                    progress_callback=progress_callback,
                 )
         except ValueError as err:
+            self._progress_reset("Помилка генерації")
             return show_error(str(err))
 
         if not records:
+            self._progress_reset("Очікування")
             return show_error("Немає даних для генерації (перевірте моделі).")
 
         # експорт
+        self._progress_message("Експорт файлів...")
         try:
             products_file = export_products(
                 records,
@@ -2179,8 +2702,10 @@ class App(ctk.CTk):
                 self.out_folder_var.get().strip(),
             )
         except Exception as e:
+            self._progress_reset("Помилка експорту")
             return show_error(f"Не вдалося зберегти файли: {e}")
 
+        self._progress_finish(f"Готово: {len(records)} рядків")
         msg = f"✅ Згенеровано {len(records)} рядків.\nФайл експорту: {products_file}"
         show_info(msg)
 


### PR DESCRIPTION
## Summary
- integrate FormulaEngine evaluation into export field generation with rich context helpers
- expose parsing/describe utilities from FormulaEngine to support validation and guidance
- enhance the export template editor with live formula/Jinja2 validation, guidance, and error messaging

## Testing
- python -m compileall main.py formula_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d1bcd8e228832586652144c0ccbb4e